### PR TITLE
Enhancement: Add optional Elasticsearch authentication

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -89,6 +89,8 @@ func analyzeHandler(logger *slog.Logger) func(http.ResponseWriter, *http.Request
 			http.Error(w, "query is required", http.StatusBadRequest)
 			return
 		}
+		username := r.FormValue("username")
+		password := r.FormValue("password")
 
 		server = strings.TrimSuffix(server, "/")
 		method = strings.ToUpper(method)
@@ -124,6 +126,10 @@ func analyzeHandler(logger *slog.Logger) func(http.ResponseWriter, *http.Request
 			return
 		}
 		esRequest.Header.Set("Content-Type", "application/json")
+
+		if username != "" && password != "" {
+			esRequest.SetBasicAuth(username, password)
+		}
 
 		esResponse, err := esClient.Do(esRequest)
 		if err != nil {

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -35,6 +35,20 @@
         <div class="row g-2 mb-3">
           <div class="col-md">
             <div class="form-floating">
+              <input type="text" class="form-control" id="username" name="username" placeholder="username">
+              <label for="username">Username</label>
+            </div>
+          </div>
+          <div class="col-md">
+            <div class="form-floating">
+              <input type="password" class="form-control" id="password" name="password" placeholder="password">
+              <label for="password">Password</label>
+            </div>
+          </div>
+        </div>
+        <div class="row g-2 mb-3">
+          <div class="col-md">
+            <div class="form-floating">
               <select class="form-select" id="method" name="method" aria-label="Method" required>
                 <option value="GET" selected>GET</option>
                 <option value="PUT">PUT</option>


### PR DESCRIPTION
Add username/password fields to allow basic authentication with Elasticsearch.

https://www.elastic.co/guide/en/elasticsearch/reference/current/http-clients.html

## Related Issue

None.

## Checklist

- [x] I have read the [contributing guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../blob/main/SECURITY.md).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [cadastros@rafael.net.br](mailto:cadastros@rafael.net.br)) from the maintainers to push the changes.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

Requested via a comment in the YouTube video:
https://www.youtube.com/watch?v=0qegA-EDIl4

<img width="1021" alt="image" src="https://github.com/user-attachments/assets/781a9dad-474f-4d80-a02c-d7eb6b7f037c">

New UI fields:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/0ce3db8f-ab4b-4bb0-b23d-a4cb4d6ede85">